### PR TITLE
Fix for InvetoryDef Properties

### DIFF
--- a/Facepunch.Steamworks/Structs/InventoryDef.cs
+++ b/Facepunch.Steamworks/Structs/InventoryDef.cs
@@ -102,7 +102,10 @@ namespace Steamworks
 
 			if ( !SteamInventory.Internal.GetItemDefinitionProperty( Id, name, out var vl, ref _ ) )
 				return null;
-
+				
+			if (name == null) //return keys string
+				return vl;
+				
 			if ( _properties == null )
 				_properties = new Dictionary<string, string>();
 


### PR DESCRIPTION
Otherwise we get error in `_properties[name] = vl;` as name is null. GetProperty(null) is called to get list of keys as string. I guess separate method would be cleaner but I'm keeping this example to minimum (or im too lazy).